### PR TITLE
fix: add support for ignoring "load" global variable

### DIFF
--- a/lj-releng
+++ b/lj-releng
@@ -177,7 +177,7 @@ sub process_file {
                                    |os|print|tonumber|math|pcall|xpcall|unpack
                                    |pairs|ipairs|assert|module|package
                                    |coroutine|[gs]etfenv|next|rawget|rawset
-                                   |loadstring|dofile|collectgarbage
+                                   |loadstring|dofile|collectgarbage|load
                                    |rawlen|select|arg|bit|debug|ngx|ndk|newproxy)$/x)
                 {
                     next;


### PR DESCRIPTION
lua global load is not covered by default by the lj-relang which is used for lint tests. This PR makes sure overrides the code with the one which takes that into account